### PR TITLE
Support reference-style links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Lets you add new reference links to the current markdown documents.
 ### Version 0.0.3
 
 * Support reference-style links: unused links are shown first, closest unused link is preferred
+* Prevent duplicate inline-links from showing up multiple times

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Lets you add new reference links to the current markdown documents.
 [Enlarged version of video](https://raw.githubusercontent.com/dfinke/vscode-GetXrefLink/master/images/GetXRefLink.gif)
 
 ![image](https://raw.githubusercontent.com/dfinke/vscode-GetXrefLink/master/images/GetXRefLink.gif)
+
+## What's New
+
+### Version 0.0.3
+
+* Support reference-style links

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Lets you add new reference links to the current markdown documents.
 
 ### Version 0.0.3
 
-* Support reference-style links
+* Support reference-style links: unused links are shown first, closest unused link is preferred

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-GetXrefLink",
 	"description": "Get xref links in a markdown doc",
 	"displayName" : "Markdown Get Xref Links",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"publisher": "DougFinke",
 	"icon": "images/logo.png",
 	

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 
 	"engines": {
-		"vscode": "^0.10.1"
+		"vscode": "^1.0.0"
 	},
 	"categories": [
 		"Other"
@@ -43,10 +43,12 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"devDependencies": {
+		"@types/node": "8.x.x",
 		"typescript": "^3.4.2",
-		"vscode": "0.10.x"
+		"vscode": "1.1.33"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -41,12 +41,14 @@
 		]
 	},
 	"scripts": {
-		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+		"vscode:prepublish": "tsc -p ./",
+		"compile": "tsc -watch -p ./",
 		"postinstall": "node ./node_modules/vscode/bin/install"
 	},
 	"devDependencies": {
 		"@types/node": "8.x.x",
+		"@types/mocha": "^2.2.32",
+		"mocha": "^2.3.3",
 		"typescript": "^3.4.2",
 		"vscode": "1.1.33"
 	}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
 	},
 	"devDependencies": {
-		"typescript": "^1.6.2",
+		"typescript": "^3.4.2",
 		"vscode": "0.10.x"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
 	"name": "vscode-GetXrefLink",
 	"description": "Get xref links in a markdown doc",
-	"displayName" : "Markdown Get Xref Links",
+	"displayName": "Markdown Get Xref Links",
 	"version": "0.0.3",
 	"publisher": "DougFinke",
 	"icon": "images/logo.png",
-	
 	"license": "SEE LICENSE",
-
 	"bugs": {
 		"url": "https://github.com/dfinke/vscode-GetXrefLink/issues",
 		"email": "finked@hotmail.com"
@@ -15,31 +13,32 @@
 	"homepage": "https://github.com/dfinke/vscode-GetXrefLink/blob/master/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/dfinke/vscode-GetXrefLink.git"      
+		"url": "https://github.com/dfinke/vscode-GetXrefLink.git"
 	},
-
 	"engines": {
 		"vscode": "^1.0.0"
 	},
 	"categories": [
 		"Other"
 	],
-	"activationEvents": [		
-        "onLanguage:markdown"        
+	"activationEvents": [
+		"onLanguage:markdown"
 	],
 	"main": "./out/src/extension",
 	"contributes": {
-		"keybindings": [			
+		"keybindings": [
 			{
 				"command": "markdown.links",
 				"key": "ctrl+shift+L",
 				"when": "editorTextFocus && editorLangId == 'markdown'"
-			}	
-		],        
-		"commands": [{
-			"command": "markdown.links",
-			"title": "Get XrefLinks in Markdown file"
-		}]
+			}
+		],
+		"commands": [
+			{
+				"command": "markdown.links",
+				"title": "Get XrefLinks in Markdown file"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,35 @@ interface ReferenceStyleQuickPickItem extends vscode.QuickPickItem {
     referenceLabel: string;
 }
 
+interface ReferenceInfos {
+    [label: string]: ReferenceInfo
+}
+
+
+/**
+ * In an invalid document, there could be duplicate references.
+ * 
+ * Thus, the key is `label-{line}-{offset}`
+ */
+
+interface UniqueReferenceDefinition { 
+    label: string; 
+    url: string;
+    position: vscode.Position;
+ };
+type ReferenceDefinition = UniqueReferenceDefinition | 'multiple-definitions';
+interface ReferenceDefinitions {
+    [label: string]: ReferenceDefinition
+}
+
+function getKey(label: string, position: vscode.Position) {
+    return `${label}-${position.line}-${position.character}`;
+}
+
+interface ReferenceInfo {
+    usageCount: number;
+}
+
 type MyQuickPickItem = InlineLinkQuickPickItem | ReferenceStyleQuickPickItem;
 
 export function activate(context: vscode.ExtensionContext) {
@@ -28,6 +57,81 @@ export function activate(context: vscode.ExtensionContext) {
         
             var text = vscode.window.activeTextEditor.document.getText();
         
+            function getReferenceDefinitions(): ReferenceDefinitions {
+                var result: ReferenceDefinitions = {}
+                var pattern = '\\[(.*)\\]:(.*)\s*$';        
+                var r = new RegExp(pattern, 'gm');
+
+                var match: RegExpExecArray;
+                var items: ReferenceStyleQuickPickItem[] = [];
+
+                while ( (match = r.exec(text)) ) {
+                    var label = match[1];
+                    var sourceOffset = match.index;
+                    var position = editor.document.positionAt(sourceOffset);
+                    if (result.hasOwnProperty(label)) {
+                        result[label] = "multiple-definitions";
+                    } else {
+                        result[label] = {
+                            label: label,
+                            url: match[2],
+                            position: position,
+                        }
+                    }
+                }
+                return result;
+            }
+
+            var referenceDefinitions = getReferenceDefinitions();
+            console.log(`Reference definitions`, referenceDefinitions);
+
+            function getDefinition(label: string): ReferenceDefinition | undefined {
+                if (referenceDefinitions.hasOwnProperty(label)) {
+                    return referenceDefinitions[label];
+                } else {
+                    return undefined;
+                }
+            }
+
+            function isDefinedInMultiplePlaces(arg: ReferenceDefinition | undefined): arg is 'multiple-definitions' {
+                if (arg === undefined) {
+                    return false;
+                }
+                return arg === 'multiple-definitions';
+            }
+
+            function isUniqueDefinition(arg: ReferenceDefinition | undefined): arg is UniqueReferenceDefinition {
+                if (arg === undefined) {
+                    return false;
+                }
+                return arg !== 'multiple-definitions';
+            }
+
+            function getReferenceUsagesByCountAscending(): ReferenceInfos {
+                var pattern = '\\[.*?\\]\\[([^\\]]+)\\]';
+                var r = new RegExp(pattern, 'gm');
+
+                var match: RegExpExecArray;
+                var result: ReferenceInfos = {};
+                
+                while ( (match = r.exec(text)) ) {
+                    var label = match[1];
+                    if (!result.hasOwnProperty(label)) {
+                        result[label] = {
+                            usageCount: 1,
+                        };
+                    } else {
+                        result[label].usageCount++;
+                    }
+                }
+                console.info(`Computed usages by label count: `, result);
+                return result;
+            }
+
+            function hasMultipleDefinitions(label: string) {
+                return referenceDefinitions.hasOwnProperty(label) && referenceDefinitions[label] === 'multiple-definitions';
+            }
+
             function inlineLinks() {
                 var pattern = '\\[(.*)\\]\\((.*)\\)';        
                 var r = new RegExp(pattern, 'gm');
@@ -47,26 +151,134 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             function referenceStyleLinks() {
-                var pattern = '\\[(.*)\\]:(.*)\s*$';        
-                var r = new RegExp(pattern, 'gm');
+                var usageCounter = getReferenceUsagesByCountAscending()
 
-                var result;
-                var items: ReferenceStyleQuickPickItem[] = [];
-                while ( (result = r.exec(text)) ) {
-                    var tag=result[1];
-                    if(tag.length === 0) {
-                        tag="image";                                
+                function getUsageCount(item: string | ReferenceStyleQuickPickItem): number {
+                    var label: string;
+                    if (typeof item === "string") {
+                        label = item;
+                    } else {
+                        label = item.referenceLabel;
                     }
-                            
-                    items.push({ label: tag, description: result[2], kind: 'reference-style', referenceLabel: result[1] }); 
+
+                    if (usageCounter.hasOwnProperty(label)) {
+                        var result = usageCounter[label].usageCount;
+                        console.log(`  getUsageCount: ${label} is ${result}`)
+                        return result;
+                    }
+
+                    return 0;
                 }
+
+                var items: ReferenceStyleQuickPickItem[] = [];
+
+                var label: string;
+                for (label in referenceDefinitions) {
+                    var definition = referenceDefinitions[label];
+
+                    if (label.length === 0) {
+                        label="image";                                
+                    }
+                    var usageCount = getUsageCount(label);
+                    var sharedProps = {
+                        kind: 'reference-style' as 'reference-style',
+                        referenceLabel: label,
+                    };
+                    
+                    if (isDefinedInMultiplePlaces(definition)) {
+                        items.push({
+                            label: label,
+                            description: 'Multiple definitions',
+                            ...sharedProps
+                        })
+                    }
+                    else if (usageCount >= 1) {
+                        var usages = usageCount > 1 ? "usages" : "usage";
+                        items.push({ 
+                            label: label, 
+                            description: ` (${usageCount} ${usages})`, 
+                            detail: definition.url, 
+                            ...sharedProps
+                        });
+                    } else {
+                        items.push({ 
+                            label: label, 
+                            description: '(Unused)', 
+                            detail: definition.url, 
+                            ...sharedProps,
+                        });
+                    }
+                    
+                }
+
+                function compare(a: ReferenceStyleQuickPickItem, b: ReferenceStyleQuickPickItem): number {
+                    const defA = getDefinition(a.referenceLabel);
+                    const defB = getDefinition(b.referenceLabel);
+                    function closestByPosition<T>(referencePosition: vscode.Position, a: T, b: T, getPos: (t: T) => vscode.Position): T {
+                        var posA = getPos(a);
+                        var posB = getPos(b);
+                        var lineDistanceA = Math.abs(posA.line - referencePosition.line);
+                        var lineDistanceB = Math.abs(posB.line - referencePosition.line);
+
+                        if (lineDistanceA < lineDistanceB) {
+                            return a;
+                        } else if (lineDistanceB < lineDistanceA) {
+                            return b;
+                        } else {
+                            // default to `a` if both are the same distance from reference position
+                            return a;
+                        }
+                    }
+                    
+                    console.log(`Comparing ${a.referenceLabel} against ${b.referenceLabel}`);
+                    if (getUsageCount(a) == 0 && getUsageCount(b) >= 1) {
+                        // Only a is unused, rank a higher
+                        console.debug(`a is unused, b is not, rank a higher`);
+                        return -1;
+                    } else if (getUsageCount(b) == 0 && getUsageCount(a) >= 1) {
+                        // Only b is unused, rank b higher
+                        console.debug(`b is unused, a is not, rank b higher`);
+                        return 1;
+                    }
+                    else  {
+                        // both have more than one usage
+
+                        // 1. Prefer closest unique definition, if both are unique
+                        // 2. Prefer unique definition over multiple definitions
+                        // 3. if both are defined in multiple places, use alphabetical order
+                        if (isUniqueDefinition(defA) && isUniqueDefinition(defB)) {
+                            var closest = closestByPosition(sls, defA, defB, def => def.position);
+                            return closest === defA ? -1 : 1;
+                        }
+                        if (isUniqueDefinition(defA) && isDefinedInMultiplePlaces(defB)) {
+                            return -1;
+                        }
+                        if (isUniqueDefinition(defB) && isDefinedInMultiplePlaces(defA)) {
+                            return 1;
+                        }
+                        if (isDefinedInMultiplePlaces(defA) && isDefinedInMultiplePlaces(defB)) {
+                            return a.label.localeCompare(b.label);
+                        }
+                        
+                        console.error("Unhandled case when comparing a and b");
+                        console.error("a", a);
+                        console.error("b", b);
+                        console.error("defA", defA);
+                        console.error("defB", defB);
+                        throw new Error("Unhandled case");
+                    }
+                }
+                
+                items.sort(compare);
+
                 return items;
             }
 
+            // always prefer reference style links over inline links
             var items: MyQuickPickItem[] = [...referenceStyleLinks(), ...inlineLinks()];
                
         
-            vscode.window.showQuickPick(items).then((qpSelection) => {
+            vscode.window.showQuickPick(items, {matchOnDetail: true}).then((qpSelection) => {
                 var range = new vscode.Range(sls.line, sls.character, sle.line, sle.character);
                 var result;
 
@@ -83,12 +295,10 @@ export function activate(context: vscode.ExtensionContext) {
                         result = '['+selectedText+']['+qpSelection.referenceLabel+ ']';
                     }
                 }
-
-                
                        
                 editor.edit((editBuilder) => {
                     editBuilder.replace(range, result);                
-		});
+                });
             });		
 	});
     	

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,13 +138,17 @@ export function activate(context: vscode.ExtensionContext) {
 
                 var result;
                 var items: InlineLinkQuickPickItem[] = [];
+                var seenUrls = new Set();
                 while ( (result = r.exec(text)) ) {
                     var tag=result[1];
                     if(tag.length === 0) {
                         tag="image";                                
                     }
-                            
-                    items.push({ label: tag, description: result[2], kind: 'inline-link', link: result[2] }); 
+                    var link = result[2];
+                    if (!seenUrls.has(link)) {
+                        seenUrls.add(link);
+                        items.push({ label: tag, description: link, kind: 'inline-link', link: link }); 
+                    }
                 }
 
                 return items;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,13 +14,6 @@ interface ReferenceInfos {
     [label: string]: ReferenceInfo
 }
 
-
-/**
- * In an invalid document, there could be duplicate references.
- * 
- * Thus, the key is `label-{line}-{offset}`
- */
-
 interface UniqueReferenceDefinition { 
     label: string; 
     url: string;
@@ -29,10 +22,6 @@ interface UniqueReferenceDefinition {
 type ReferenceDefinition = UniqueReferenceDefinition | 'multiple-definitions';
 interface ReferenceDefinitions {
     [label: string]: ReferenceDefinition
-}
-
-function getKey(label: string, position: vscode.Position) {
-    return `${label}-${position.line}-${position.character}`;
 }
 
 interface ReferenceInfo {

--- a/test/test.md
+++ b/test/test.md
@@ -1,0 +1,28 @@
+# Test Document Using Hyperlinks
+
+This document uses an inline [link](http://example.com/inline-link-1)
+
+This document uses a second inline link [link](http://example.com/inline-link-2)
+
+This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
+This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
+This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
+This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
+
+This document uses the reference-style-link [used-1][used-1-time] one time.
+
+This paragraph uses the reference-style-link [used-2][used-2-times] two times: [used-2][used-2-times].
+
+Test links here: 
+
+[multiple-def]: http://example.com/multiple-def-1
+[multiple-def]: http://example.com/multiple-def-2
+
+[multiple-def-unused]: http://example.com/multiple-def-1--unused
+[multiple-def-unused]: http://example.com/multiple-def-2--unused
+
+[used-1-time]: http://example.com/used-1-time
+[used-2-times]: http://example.com/used-2-times
+
+[unused-1]: http://example.com/unused-1
+[unused-2]: http://example.com/unused-2

--- a/test/test.md
+++ b/test/test.md
@@ -4,10 +4,10 @@ This document uses an inline [link](http://example.com/inline-link-1)
 
 This document uses a second inline link [link](http://example.com/inline-link-2)
 
-This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
-This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
-This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
-This document uses an inline multiple times [link](http://example.com/inline-link-multiple-times)
+This document uses an inline multiple times [multiple-times-1](http://example.com/inline-link-multiple-times)
+This document uses an inline multiple times [multiple-times-2](http://example.com/inline-link-multiple-times)
+This document uses an inline multiple times [multiple-times-3](http://example.com/inline-link-multiple-times)
+This document uses an inline multiple times [multiple-times-4](http://example.com/inline-link-multiple-times)
 
 This document uses the reference-style-link [used-1][used-1-time] one time.
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "es5",
+		"target": "es6",
 		"outDir": "out",
 		"sourceMap": true,
-		"lib": ["es5"],
+		"lib": ["es6"],
 	},
 	"exclude": [
 		"node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"target": "es5",
 		"outDir": "out",
-		"noLib": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"lib": ["es5"],
 	},
 	"exclude": [
 		"node_modules"


### PR DESCRIPTION
The extension now supports the completion of reference-style links.
It will prefer unused references over used ones, closer references are preferred.

```md

[Reference-style link][reference]

[reference]: http://example.com
```

I have also fixed a "bug" where duplicate inline links would show up multiple times.

Infrastructure changes:

* Bumped required VSCode version to 1.0.0 (to support `description` inside `showQuickPick`)
* Upgraded TypeScript to latest version (to support discriminated unions, requires TS >= 2)
* ES6 to support `Set`
* misc `package.json` adjustments to make the above changes work